### PR TITLE
pymemcache and Django 4.2.30

### DIFF
--- a/stgospel/settings/base.py
+++ b/stgospel/settings/base.py
@@ -61,7 +61,7 @@ ADMINS = (
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': '127.0.0.1:11211',
         'TIMEOUT': None,
     }


### PR DESCRIPTION
Add pymemcache Module as required by django 4.2.30